### PR TITLE
Add support for Rust code built through Cargo

### DIFF
--- a/cosy.py
+++ b/cosy.py
@@ -156,11 +156,12 @@ def parse_elffile(elffile, prefix, appdir, riot_base=None):
             riot_base=riot_base, appdir=appdir.strip("/"))
     c = re.compile(r"(?P<addr>[0-9a-f]+) "
                    r"(?P<type>[tbdTDB]) "
-                   r"(?P<sym>[0-9a-zA-Z_]+)\s+"
+                   r"(?P<sym>[0-9a-zA-Z_$.]+)\s+"
                    r"(.+/)?({riot_base}|({riot_base})/build|"
+                   r".cargo/registry/src/[^/]+|"
                    r"{appdir}/.*bin/pkg)/"
                    r"(?P<path>.+)/"
-                   r"(?P<file>[0-9a-zA-Z_-]+\.[ch]):"
+                   r"(?P<file>[0-9a-zA-Z_-]+\.(c|h|rs)):"
                    r"(?P<line>\d+)$".format(riot_base=riot_base,
                                             appdir=appdir))
     for line in dump.splitlines():

--- a/cosy.py
+++ b/cosy.py
@@ -225,7 +225,7 @@ def parse_mapfile(mapfile):
                     continue
 
                 # start of a new symbol
-                m = re.match(" \.([a-z]+\.)?([-_\.A-Za-z0-9]+)", line)
+                m = re.match(" \.([a-z]+\.)?([-_\.A-Za-z0-9$.]+)", line)
                 if m:
                     # save last symbol
                     add_sym(res, cur_sym)

--- a/cosy.py
+++ b/cosy.py
@@ -159,6 +159,8 @@ def parse_elffile(elffile, prefix, appdir, riot_base=None):
                    r"(?P<sym>[0-9a-zA-Z_$.]+)\s+"
                    r"(.+/)?({riot_base}|({riot_base})/build|"
                    r".cargo/registry/src/[^/]+|"
+                   r".cargo/git/checkouts|"
+                   r"/rustc/[0-9a-f]+/?/library|"
                    r"{appdir}/.*bin/pkg)/"
                    r"(?P<path>.+)/"
                    r"(?P<file>[0-9a-zA-Z_-]+\.(c|h|rs)):"


### PR DESCRIPTION
This recognizes the .rs extension, and extends the pattern matching to
both recognize Rust symbols (with their mangled names, no demangling in
here yet) and to recognize paths stemming from Rust's build system. (One
path component is stripped as it represents the overall repository a
packet comes from, currently usually "github", and is not really helpful
to the user).

---

Most easily tested with https://github.com/RIOT-OS/RIOT/pull/16274 -- then, `make cosy` shows crates independently.