### PR TITLE
Adapt regex to fit current nm output

### DIFF
--- a/cosy.py
+++ b/cosy.py
@@ -162,7 +162,7 @@ def parse_elffile(elffile, prefix, appdir, riot_base=None):
     c = re.compile(r"(?P<addr>[0-9a-f]+) "
                    r"(?P<type>[tbdTDB]) "
                    r"(?P<sym>[0-9a-zA-Z_$.]+)\s+"
-                   r"(.+/)?"
+                   r"(.*/)?"
                    r"("
                    r"{appdir}|"
                    r"{riot_base}|"


### PR DESCRIPTION
Not sure why the regex expected other characters before the '/' which indicates the path of the source file, but at least my version of nm (2.38) is not printing anything else than whitespaces before the slash.
